### PR TITLE
Refresh

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,7 +6,7 @@ package:
 
 source:
   fn: pyelftools-{{ version }}.tar.gz
-  url: https://pypi.python.org/packages/source/p/pyelftools/pyelftools-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/p/pyelftools/pyelftools-{{ version }}.tar.gz
   md5: aa7cefa8bd2f63d7b017440c9084f310
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
 source:
   fn: pyelftools-{{ version }}.tar.gz
   url: https://pypi.org/packages/source/p/pyelftools/pyelftools-{{ version }}.tar.gz
-  md5: aa7cefa8bd2f63d7b017440c9084f310
+  sha256: fc57aadd096e8f9b9b03f1a9578f673ee645e1513a5ff0192ef439e77eab21de
 
 build:
   skip: True  # [not linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -30,7 +30,7 @@ test:
 
 about:
   home: https://github.com/eliben/pyelftools
-  license: Public domain
+  license: Public Domain
   license_file: LICENSE
   summary: Library for analyzing ELF files and DWARF debugging information
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -31,6 +31,7 @@ test:
 about:
   home: https://github.com/eliben/pyelftools
   license: Public domain
+  license_file: LICENSE
   summary: 'Library for analyzing ELF files and DWARF debugging information'
 
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -32,7 +32,7 @@ about:
   home: https://github.com/eliben/pyelftools
   license: Public domain
   license_file: LICENSE
-  summary: 'Library for analyzing ELF files and DWARF debugging information'
+  summary: Library for analyzing ELF files and DWARF debugging information
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   skip: True  # [not linux]
-  number: 0
+  number: 1
 
 requirements:
   build:


### PR DESCRIPTION
* Use the Warehouse redirect URL for PyPI.
* Switch from `md5` to `sha256`.
* Package the license file. (requires a rebuild)
* Some other small tweaks