### PR TITLE
Release 0.24

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "0.23" %}
+{% set version = "0.24" %}
 
 package:
   name: pyelftools
@@ -7,11 +7,11 @@ package:
 source:
   fn: pyelftools-{{ version }}.tar.gz
   url: https://pypi.org/packages/source/p/pyelftools/pyelftools-{{ version }}.tar.gz
-  sha256: fc57aadd096e8f9b9b03f1a9578f673ee645e1513a5ff0192ef439e77eab21de
+  sha256: e9dd97d685a5b96b88a988dabadb88e5a539b64cd7d7927fac9a7368dc4c459c
 
 build:
   skip: True  # [not linux]
-  number: 1
+  number: 0
 
 requirements:
   build:


### PR DESCRIPTION
```
+ Version 0.24 (04.08.2016)

  - Retrieve symbols by name - get_symbol_by_name (#58).
  - Symbol/section names are strings internally now, not bytestrings (this may
    affect API usage in Python 3) (#76).
  - Added DT_MIPS_* constants to ENUM_D_TAG (#79)
  - Made dwarf_decode_address example a bit more useful for command-line
    invocation.
  - More DWARF v4 support w.r.t decoding function ranges; DW_AT_high_pc value
    is now either absolute or relative to DW_AT_low_pc, depending on the class
    of the form encoded in the file. Also #89.
  - Support for SHT_NOTE sections (#109)
  - Support for .debug_aranges section (#108)
  - Support for zlib-compressed debug sections (#102)
  - Support for DWARF v4 line programs (#82)
```